### PR TITLE
fixed issue where creating service desk request reponse was erroring out

### DIFF
--- a/cloud/request.go
+++ b/cloud/request.go
@@ -26,7 +26,7 @@ type Request struct {
 type RequestFieldValue struct {
 	FieldID string `json:"fieldId,omitempty" structs:"fieldId,omitempty"`
 	Label   string `json:"label,omitempty" structs:"label,omitempty"`
-	Value   string `json:"value,omitempty" structs:"value,omitempty"`
+	Value   interface{} `json:"value,omitempty" structs:"value,omitempty"`
 }
 
 // RequestDate is the date format used in requests.
@@ -66,12 +66,12 @@ func (r *RequestService) Create(ctx context.Context, requester string, participa
 
 	payload := struct {
 		*Request
-		FieldValues  map[string]string `json:"requestFieldValues,omitempty"`
+		FieldValues  map[string]interface{} `json:"requestFieldValues,omitempty"`
 		Requester    string            `json:"raiseOnBehalfOf,omitempty"`
 		Participants []string          `json:"requestParticipants,omitempty"`
 	}{
 		Request:      request,
-		FieldValues:  make(map[string]string),
+		FieldValues:  make(map[string]interface{}),
 		Requester:    requester,
 		Participants: participants,
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/andygrunwald/go-jira/v2
 
 go 1.21
 
-toolchain go1.23
+toolchain go1.23.0
 
 require (
 	github.com/fatih/structs v1.1.0


### PR DESCRIPTION
#### What type of PR is this?
bug
<!--
Add one of the following kinds:
* bug
* cleanup
* documentation
* feature

Optionally add one or more of the following kinds if applicable:
* api-change
* deprecation
-->

#### What this PR does / why we need it:
Creating a servicedesk request via the SDK fails to handle the response. 
SDK assumes that value in RequestFieldValue is always string. But it is not the case. 


#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:
This is the error I was getting while using the SDK.
```
2025/06/11 12:33:34 [DEBUG] POST https://support.solaris-testing.de/rest/servicedeskapi/request
{"level":"error","message":"Failed to create request: json: cannot unmarshal array into Go struct field RequestFieldValue.requestFieldValues.value of type string: file already closed"}
{"level":"error","message":"Failed to create request: json: cannot unmarshal array into Go struct field RequestFieldValue.requestFieldValues.value of type string: file already closed, response: "}
```
Below is a sample of requestFieldValues in the response from Jira API. As you can see value is not always string.
```
  "requestFieldValues": [
    {
      "fieldId": "summary",
      "label": "Summary",
      "value": "Test issue finom"
    },
    {
      "fieldId": "description",
      "label": "Description",
      "value": "Creating an issue with the go-jira client"
    },
    {
      "fieldId": "attachment",
      "label": "Attachment",
      "value": [],
      "renderedValue": []
    },
    {
      "fieldId": "customfield_21700",
      "label": "",
      "value": []
    }
  ],
```

#### Additional documentation e.g., usage docs, etc.:
